### PR TITLE
Minor modification to support removeModifier in SpanParser

### DIFF
--- a/src/Text/SpanParser.php
+++ b/src/Text/SpanParser.php
@@ -113,7 +113,15 @@ final class SpanParser
         if ($attribute === 'options') {
             $options = explode(',', $value);
             foreach ($options as $option) {
-                $style->addModifier(Modifier::fromName($option));
+                $isRemove = str_starts_with($option, '~');
+                $name = $isRemove ? mb_substr($option, 1) : $option;
+                $modifier = Modifier::fromName($name);
+
+                if ($isRemove) {
+                    $style->removeModifier($modifier);
+                } else {
+                    $style->addModifier($modifier);
+                }
             }
         }
 

--- a/tests/Unit/Text/SpanParserTest.php
+++ b/tests/Unit/Text/SpanParserTest.php
@@ -312,4 +312,24 @@ final class SpanParserTest extends TestCase
         self::assertSame(' demo application.', $thirdSpan->content);
         self::assertNull($thirdSpan->style->fg);
     }
+
+    public function testParseTwoTagsWithRemoveModifier(): void
+    {
+        $spans = SpanParser::new()->parse('<fg=green;bg=blue;options=bold,italic>Hello <fg=red;options=~bold>World</></>');
+        self::assertCount(2, $spans);
+
+        $firstSpan = $spans[0];
+        self::assertSame('Hello ', $firstSpan->content);
+        self::assertSame(AnsiColor::Green, $firstSpan->style->fg);
+        self::assertSame(AnsiColor::Blue, $firstSpan->style->bg);
+        self::assertTrue(($firstSpan->style->addModifiers & Modifier::BOLD) === Modifier::BOLD);
+        self::assertTrue(($firstSpan->style->addModifiers & Modifier::ITALIC) === Modifier::ITALIC);
+
+        $secondSpan = $spans[1];
+        self::assertSame('World', $secondSpan->content);
+        self::assertSame(AnsiColor::Red, $secondSpan->style->fg);
+        self::assertSame(AnsiColor::Blue, $secondSpan->style->bg);
+        self::assertTrue(($secondSpan->style->addModifiers & Modifier::ITALIC) === Modifier::ITALIC);
+        self::assertTrue($secondSpan->style->subModifiers === Modifier::BOLD);
+    }
 }


### PR DESCRIPTION
This minor change adds support for removing style modifiers in the options attribute by prefixing them with a tilde (~).
With this change, you can now explicitly remove a modifier by writing something like ~italic, which makes it easier to override modifiers in nested tag situations when required.

The implementation just checks if an option starts with ~, and if so, strips that off and removes the corresponding modifier from the style instead of adding it.

That said, I'm not totally sure if you're happy with the use of ~ for this. If you’d prefer a different character (like -), or even a separate attribute for removed modifiers, I’m totally open to changing the approach based on your preference!